### PR TITLE
Fix popts regex for 516 style links

### DIFF
--- a/resources/js/Pages/Admin/Logs/Partials/LogEntry.vue
+++ b/resources/js/Pages/Admin/Logs/Partials/LogEntry.vue
@@ -128,7 +128,7 @@ export default {
       message += this.log.message || ''
 
       const poptsRegex =
-        /<a href='\?src=%admin_ref%;action=adminplayeropts;targetckey=.*?' title='Player Options'>(.*?) \((.*?)\)<\/a>/g
+        /<a href='byond:\/\/\?src=%admin_ref%;action=adminplayeropts;targetckey=.*?' title='Player Options'>(.*?) \((.*?)\)<\/a>/g
       message = message.replaceAll(
         poptsRegex,
         '<span class="log-player">$1 (<a href="/admin/players/$2" target="_blank">$2</a>)</span>'


### PR DESCRIPTION
https://github.com/goonstation/goonstation/pull/23094 changed the format of the player options links inserted into logs because Byond 516 now requires the `byond://` part. This PR updates the regex used to swap this URL out for the website links on the web logs.