### PR TITLE
get playercount for invisible servers too

### DIFF
--- a/app/Jobs/GetPlayerCounts.php
+++ b/app/Jobs/GetPlayerCounts.php
@@ -33,8 +33,8 @@ class GetPlayerCounts implements ShouldQueue
      */
     public function handle()
     {
-        // Get player count for all active servers
-        $servers = GameServer::where('active', true)->where('invisible', false)->get();
+        // Get player count for all active servers (including invisible ones so their counts are tracked)
+        $servers = GameServer::where('active', true)->get();
 
         $when = Carbon::now();
         foreach ($servers as $server) {


### PR DESCRIPTION
this is so we can know the amount of players on the tomato servers

it is important to note this would let people see how many people there on dev as well