### PR TITLE
Fix jobban duration

### DIFF
--- a/app/Traits/ManagesJobBans.php
+++ b/app/Traits/ManagesJobBans.php
@@ -26,7 +26,10 @@ trait ManagesJobBans
 
         $expiresAt = null;
         if ($data->has('duration')) {
-            $expiresAt = Carbon::now()->addSeconds($data['duration']);
+            $duration = (int) $data['duration'];
+            if ($duration > 0) {
+                $expiresAt = Carbon::now()->addSeconds($duration);
+            }
         }
 
         $gameAdmin = $request->getGameAdmin();


### PR DESCRIPTION
Makes jobbans handle duration in the same way regular bans do (as the game server seems to expect them to be handled)
I can't test this, because I can't build this repo locally, but it should be safe. All other ban duration handling looks to be the same between bans and jobbans.