### PR TITLE
adds byond-tracy-writer goonhub code

### DIFF
--- a/.github/workflows/byond-tracy-writer.yml
+++ b/.github/workflows/byond-tracy-writer.yml
@@ -1,0 +1,45 @@
+name: BYOND-Tracy-Writer
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: goonstation/byond-tracy-writer git ref
+        type: string
+        default: master
+  repository_dispatch:
+    types: [byond_tracy_writer_update]
+
+jobs:
+  build:
+    name: Build and upload latest release
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: goonstation/byond-tracy-writer
+          ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'master' }}
+
+      - run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install zip gcc-multilib libc6-dev-i386
+
+      - name: Build
+        run: gcc -m32 -shared -fPIC -O2 -o libprof.so prof.c
+
+      - run: zip latest.zip libprof.so
+
+      - uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.BYOND_TRACY_WRITER_RELEASES_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.BYOND_TRACY_WRITER_RELEASES_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BYOND_TRACY_WRITER_RELEASES_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.BYOND_TRACY_WRITER_RELEASES_BUCKET }}
+          source-dir: './latest.zip'
+          destination-dir: ./
+          keep-file-fresh: true

--- a/app/Http/Controllers/Api/GameBuildArtifactsController.php
+++ b/app/Http/Controllers/Api/GameBuildArtifactsController.php
@@ -107,4 +107,19 @@ class GameBuildArtifactsController extends Controller
 
         return response()->download($path);
     }
+
+    /**
+     * Download BYOND Tracy Writer
+     */
+    public function byondTracyWriter()
+    {
+        $buildPath = Build::$path;
+        $path = storage_path("$buildPath/byond-tracy-writer/latest.zip");
+
+        if (! file_exists($path)) {
+            return abort(404);
+        }
+
+        return response()->download($path);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -208,6 +208,7 @@ Route::middleware(['isadmin'])->group(function () {
         Route::get('/game', 'game');
         Route::get('/byond', 'byond');
         Route::get('/rustg', 'rustg');
+        Route::get('/byond-tracy-writer', 'byondTracyWriter');
     });
     Route::controller(OrchestrationController::class)->prefix('orchestration')->group(function () {
         Route::get('/status', 'status');


### PR DESCRIPTION
Unsure if just always pushing latest as an artifact is best. It's not like we really care about 'versions' for this, we always want the latest. But downloading and pushing the latest every build seems a bit... eh


Triggers off of https://github.com/goonstation/byond-tracy-writer/blob/master/.github/workflows/notify.yml - secret already set for this

Also assumes the r2 url is set to `byond-tracy-writer.goonhub.com`

## needed github secrets
- `BYOND_TRACY_WRITER_RELEASES_ACCOUNT_ID`
- `BYOND_TRACY_WRITER_RELEASES_ACCESS_KEY_ID`
- `BYOND_TRACY_WRITER_RELEASES_SECRET_ACCESS_KEY`
- `BYOND_TRACY_WRITER_RELEASES_BUCKET`

