### PR TITLE
Player Stats API response include per-department rounds played

### DIFF
--- a/app/Http/Controllers/Api/PlayersController.php
+++ b/app/Http/Controllers/Api/PlayersController.php
@@ -278,6 +278,18 @@ class PlayersController extends Controller
                             $query->whereNot('round_id', null)->whereRelation('gameRound', 'rp_mode', '=', true);
                         });
                 },
+                'participations as played_security' => function (Builder $query) {
+                    $query->where('job', 'Security Officer')->orWhere('job', 'Security Assistant');
+                },
+                'participations as played_medical' => function (Builder $query) {
+                    $query->where('job','Medical Doctor')->orWhere('job', 'Medical Trainee');
+                },
+                'participations as played_research' => function (Builder $query) {
+                    $query->where('job', 'Scientist')->orWhere('job', 'Research Trainee');
+                },
+                'participations as played_engineering' => function (Builder $query) {
+                    $query->where('job', 'Engineer')->orWhere('job', 'Technical Trainee');
+                },
                 'connections as connected' => function (Builder $query) {
                     $query->where(function (Builder $query) {
                         $query->where('round_id', null)->whereNot('legacy_data->rp_mode', true);

--- a/app/Http/Resources/PlayerStatsResource.php
+++ b/app/Http/Resources/PlayerStatsResource.php
@@ -13,6 +13,10 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property int $connected
  * @property int $connected_rp
  * @property int $time_played
+ * @property int $played_security
+ * @property int $played_medical
+ * @property int $played_research
+ * @property int $played_engineering
  */
 class PlayerStatsResource extends JsonResource
 {
@@ -38,6 +42,14 @@ class PlayerStatsResource extends JsonResource
             'played' => $this->played,
             /** @var int */
             'played_rp' => $this->played_rp,
+            /** @var int */
+            'played_security' => $this->played_security,
+            /** @var int */
+            'played_medical' => $this->played_medical,
+            /** @var int */
+            'played_research' => $this->played_research,
+            /** @var int */
+            'played_engineering' => $this->played_engineering,
             /** @var int */
             'connected' => $this->connected,
             /** @var int */


### PR DESCRIPTION
This PR adds four new entries to the PlayerStats API response, one each for the departments Security, Medical, Research, and Engineering. This will be used in-game to limit trainee roles based on number of rounds played in those departments as opposed to total rounds played.